### PR TITLE
Add entry point so we can do this conversion in the commandline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ HERE = os.path.dirname(__file__)
 
 setup(
     name = "x256",
-    version = '0.0.2',
+    version = '0.0.3',
     description = "x256: manipulate xterm 256 color codes",
     author = "Martin Garcia",
     author_email = "newluxfero@gmail.com",
@@ -34,4 +34,9 @@ setup(
         "Operating System :: OS Independen",
         "Topic :: Utilities",
     ],
+    entry_points={
+        'console_scripts': [
+            'x256 = x256.x256:entry',
+        ]
+    },
 )

--- a/x256/x256.py
+++ b/x256/x256.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import argparse
+
 from math import sqrt
 
 
@@ -315,6 +317,28 @@ def to_hex(i):
     Return hex color from xterm 256 color code.
     """
     return __rgb2hex(colors[i])
+
+def entry():
+    """Parse command line arguments and run utilities."""
+    parser = argparse.ArgumentParser(
+        usage='%(prog)s', description=__doc__,
+    )
+    parser.add_argument(
+        'action', help='Action to take',
+        choices=['from_hex', 'to_rgb', 'to_hex'],
+    )
+    parser.add_argument(
+        'value', help='Value for the action', nargs='1'
+    )
+    parser.parse_args()
+    if parser.action != "from_hex":
+        try:
+            parser.value = int(parser.value)
+        except ValueError:
+            raise argparse.ArgumentError(
+                "Value for this action should be an integer",
+            )
+    locals().get(parser.action)(parser.value)
 
 
 if __name__ == "__main__":

--- a/x256/x256.py
+++ b/x256/x256.py
@@ -320,25 +320,23 @@ def to_hex(i):
 
 def entry():
     """Parse command line arguments and run utilities."""
-    parser = argparse.ArgumentParser(
-        usage='%(prog)s', description=__doc__,
-    )
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         'action', help='Action to take',
         choices=['from_hex', 'to_rgb', 'to_hex'],
     )
     parser.add_argument(
-        'value', help='Value for the action', nargs='1'
+        'value', help='Value for the action',
     )
-    parser.parse_args()
-    if parser.action != "from_hex":
+    parsed = parser.parse_args()
+    if parsed.action != "from_hex":
         try:
-            parser.value = int(parser.value)
+            parsed.value = int(parsed.value)
         except ValueError:
             raise argparse.ArgumentError(
                 "Value for this action should be an integer",
             )
-    locals().get(parser.action)(parser.value)
+    print(globals()[parsed.action](parsed.value))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi Martin,

Hope you won't mind me adding an entry point for this handy tool.  :)

After the patch, it would work like this:

```
[~/ve/bin]x256 --help
usage: x256 [-h] {from_hex,to_rgb,to_hex} value

positional arguments:
  {from_hex,to_rgb,to_hex}
                        Action to take
  value                 Value for the action

optional arguments:
  -h, --help            show this help message and exit


[~/venv/bin]x256 from_hex 57C3C2
57C3C2
[~/venv/bin]x256 from_hex 57C3C2
79
[~/venv/bin]x256 to_hex 79
5FD7AF
[~/venv/bin]x256 to_rgb 79
[95, 215, 175]
```

Also, I hope you won't mind me bumping the verison.   :D